### PR TITLE
Use eater_days instead of easter_date

### DIFF
--- a/lib/Checkdomain/Holiday/Provider/AbstractEaster.php
+++ b/lib/Checkdomain/Holiday/Provider/AbstractEaster.php
@@ -17,7 +17,8 @@ abstract class AbstractEaster extends AbstractProvider
      */
     protected function getEasterDates($year)
     {
-        $easterSunday = new \DateTime('@'.easter_date($year));
+        $easterSunday = new \DateTime('21.03.'.$year);
+        $easterSunday->modify(sprintf('+%d days', easter_days($year)));
         $easterSunday->setTimezone(new \DateTimeZone(ini_get('date.timezone')));
 
         $easterMonday = clone $easterSunday;

--- a/tests/Checkdomain/Holiday/UtilTest.php
+++ b/tests/Checkdomain/Holiday/UtilTest.php
@@ -71,7 +71,11 @@ class UtilTest extends \PHPUnit_Framework_TestCase
                 'name' => 'Tag der Arbeit',
                 'national' => true
             ))),
-            array('02.01.2013', 'DE', array(false, null))
+            array('02.01.2013', 'DE', array(false, null)),
+            array('26.04.2038', 'DE', array(true, array(
+                'name' => 'Ostermontag',
+                'national' => true
+            )))
         );
     }
 


### PR DESCRIPTION
As describe in the first note of the documentation : http://www.php.net/manual/en/function.easter-date.php

It's better to use easter_days to avoid warning if the year is not inside of the range for the UNIX timestamps (i.e. before 1970 or after 2037).
