### PR TITLE
[BUGFIX] Mark national holidays as state-holidays as well

### DIFF
--- a/lib/Checkdomain/Holiday/Provider/AbstractProvider.php
+++ b/lib/Checkdomain/Holiday/Provider/AbstractProvider.php
@@ -67,6 +67,10 @@ abstract class AbstractProvider implements ProviderInterface
             return true;
         }
 
+        if ($holiday->getNational() === true) {
+            return true;
+        }
+
         if (is_array($holiday->getStates()) && in_array($state, $holiday->getStates())) {
             return true;
         }

--- a/lib/Checkdomain/Holiday/Provider/AbstractProvider.php
+++ b/lib/Checkdomain/Holiday/Provider/AbstractProvider.php
@@ -67,7 +67,7 @@ abstract class AbstractProvider implements ProviderInterface
             return true;
         }
 
-        if ($holiday->getNational() === true) {
+        if (empty($holiday->getStates())) {
             return true;
         }
 

--- a/lib/Checkdomain/Holiday/Provider/AbstractProvider.php
+++ b/lib/Checkdomain/Holiday/Provider/AbstractProvider.php
@@ -67,11 +67,12 @@ abstract class AbstractProvider implements ProviderInterface
             return true;
         }
 
-        if (empty($holiday->getStates())) {
+        $states = $holiday->getStates();
+        if (empty($states)) {
             return true;
         }
 
-        if (is_array($holiday->getStates()) && in_array($state, $holiday->getStates())) {
+        if (is_array($states) && in_array($state, $states)) {
             return true;
         }
 


### PR DESCRIPTION
If a holiday is a national holiday and it was requested if this day is a holiday in a specific state, the library would indicate "no, it is not a holiday".