### PR TITLE
setting date_default_timezone_set() has no effect

### DIFF
--- a/lib/Checkdomain/Holiday/Provider/AbstractEaster.php
+++ b/lib/Checkdomain/Holiday/Provider/AbstractEaster.php
@@ -19,7 +19,7 @@ abstract class AbstractEaster extends AbstractProvider
     {
         $easterSunday = new \DateTime('21.03.'.$year);
         $easterSunday->modify(sprintf('+%d days', easter_days($year)));
-        $easterSunday->setTimezone(new \DateTimeZone(ini_get('date.timezone')));
+        $easterSunday->setTimezone(new \DateTimeZone(date_default_timezone_get()));
 
         $easterMonday = clone $easterSunday;
         $easterMonday->modify('+1 day');


### PR DESCRIPTION
On my production server the timezone is not set in php.ini, but it is set per application in this way 
```php 
date_default_timezone_set('Europe/Berlin');
```
But it has no effect when you initialize timezone like this
```php 
new \DateTimeZone(ini_get('date.timezone'))
```