### PR TITLE
Added missing holiday for DE Provider

### DIFF
--- a/lib/Checkdomain/Holiday/Provider/DE.php
+++ b/lib/Checkdomain/Holiday/Provider/DE.php
@@ -65,6 +65,10 @@ class DE extends AbstractEaster
                 self::STATE_RP,
                 self::STATE_SL,
             )),
+            '08-15' => $this->createData('Mariä Himmelfahrt', array(
+                self::STATE_BY,
+                self::STATE_SL,
+            )),
 
             // Variable dates
             $easter['goodFriday']->format(self::DATE_FORMAT)      => $this->createData('Karfreitag'),

--- a/tests/Checkdomain/Holiday/Provider/DETest.php
+++ b/tests/Checkdomain/Holiday/Provider/DETest.php
@@ -31,6 +31,7 @@ class DETest extends AbstractTest
             array('19.06.2014', DE::STATE_SH, null),
             array('01.11.2014', DE::STATE_BW, array('name' => 'Allerheiligen')),
             array('01.11.2014', DE::STATE_SH, null),
+			array('15.08.2016', DE::STATE_SL, array('name' => 'Mariä Himmelfahrt')),
         );
     }
 }


### PR DESCRIPTION
- Added the missing holiday "Mariä Himmelfahrt" for Bayern and Saarland.
- Added holiday to the tests too

More info here: 
https://de.wikipedia.org/wiki/Mari%C3%A4_Aufnahme_in_den_Himmel
https://en.wikipedia.org/wiki/Assumption_of_Mary