### PR TITLE
Portugal Holidays

### DIFF
--- a/lib/Checkdomain/Holiday/Provider/PT.php
+++ b/lib/Checkdomain/Holiday/Provider/PT.php
@@ -24,17 +24,20 @@ class PT extends AbstractEaster
             '04-25' => $this->createData('25 de Abril'),
             '05-01' => $this->createData('Dia do Trabalhador'),
             '06-10' => $this->createData('Dia de Portugal'),
-            '06-15' => $this->createData('Corpo de Deus'),
             '08-15' => $this->createData('Assunção de Nossa Senhora'),
-            '10-05' => $this->createData('Implantação da República'),
-            '11-01' => $this->createData('Dia de Todos os Santos'),
-            '12-01' => $this->createData('Restauração da Independência'),
             '12-08' => $this->createData('Dia da Imaculada Conceição'),
             '12-25' => $this->createData('Natal'),
             // Variable dates
             $easter['goodFriday']->format(self::DATE_FORMAT)    => $this->createData('Sexta-Feira Santa'),
             $easter['easterSunday']->format(self::DATE_FORMAT)    => $this->createData('Páscoa'),
         );
+        //add holidays post 2015
+        if ($year >= 2016) {
+            $holidays['05-26'] = $this->createData('Corpo de Deus');
+            $holidays['10-05'] = $this->createData('Implantação da República');
+            $holidays['11-01'] = $this->createData('Dia de Todos os Santos');
+            $holidays['12-01'] = $this->createData('Restauração da Independência');
+        }
 
         return $holidays;
     }

--- a/lib/Checkdomain/Holiday/Provider/PT.php
+++ b/lib/Checkdomain/Holiday/Provider/PT.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Checkdomain\Holiday\Provider;
+
+/**
+ * Portugal holiday provider
+ *
+ * @author Tiago Carvalho <tiago.carvalho@beubi.com>
+ */
+class PT extends AbstractEaster
+{
+
+    /**
+     * @param int $year
+     *
+     * @return mixed
+     */
+    public function getHolidaysByYear($year)
+    {
+        $easter = $this->getEasterDates($year);
+
+        $holidays = array(
+            '01-01' => $this->createData('Ano Novo'),
+            '04-25' => $this->createData('25 de Abril'),
+            '05-01' => $this->createData('Dia do Trabalhador'),
+            '06-10' => $this->createData('Dia de Portugal'),
+            '06-15' => $this->createData('Corpo de Deus'),
+            '08-15' => $this->createData('Assunção de Nossa Senhora'),
+            '10-05' => $this->createData('Implantação da República'),
+            '11-01' => $this->createData('Dia de Todos os Santos'),
+            '12-01' => $this->createData('Restauração da Independência'),
+            '12-08' => $this->createData('Dia da Imaculada Conceição'),
+            '12-25' => $this->createData('Natal'),
+            // Variable dates
+            $easter['goodFriday']->format(self::DATE_FORMAT)    => $this->createData('Sexta-Feira Santa'),
+            $easter['easterSunday']->format(self::DATE_FORMAT)    => $this->createData('Páscoa'),
+        );
+
+        return $holidays;
+    }
+}

--- a/tests/Checkdomain/Holiday/Provider/PTTest.php
+++ b/tests/Checkdomain/Holiday/Provider/PTTest.php
@@ -36,7 +36,7 @@ class PTTest extends AbstractTest
             array('01.05.2014', null, array('name' => 'Dia do Trabalhador')),
 
             array('01.12.2015', null, null),
-            array('15.08.2015', null, array('name' => 'Santo Stefano')),
+            array('15.08.2015', null, array('name' => 'Assunção de Nossa Senhora')),
 
             array('01.01.2016', null, null),
             array('01.11.2016', null, array('name' => 'Dia de Todos os Santos')),

--- a/tests/Checkdomain/Holiday/Provider/PTTest.php
+++ b/tests/Checkdomain/Holiday/Provider/PTTest.php
@@ -38,7 +38,7 @@ class PTTest extends AbstractTest
             array('01.12.2015', null, null),
             array('15.08.2015', null, array('name' => 'Assunção de Nossa Senhora')),
 
-            array('01.01.2016', null, null),
+            array('02.01.2016', null, null),
             array('01.11.2016', null, array('name' => 'Dia de Todos os Santos')),
             array('25.12.2016', null, array('name' => 'Natal')),
 

--- a/tests/Checkdomain/Holiday/Provider/PTTest.php
+++ b/tests/Checkdomain/Holiday/Provider/PTTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Portuguese holiday provider
+ *
+ * @author Tiago Carvalho <tiago.carvalho@beubi.com>
+ */
+namespace Checkdomain\Holiday\Provider;
+
+/**
+ * Class PTTest
+ */
+class PTTest extends AbstractTest
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        $this->provider = new PT();
+    }
+
+    /**
+     * Provides some test dates and the expectation
+     *
+     * @return array
+     */
+    public function dateProvider()
+    {
+        return array(
+			      array('01.01.2010', null, array('name' => 'Ano Novo')),
+
+            array('26.05.2013', null, null),
+            array('25.04.2013', null, array('name' => '25 de Abril')),
+
+            array('05.10.2014', null, null),
+            array('01.05.2014', null, array('name' => 'Dia do Trabalhador')),
+
+            array('01.12.2015', null, null),
+            array('15.08.2015', null, array('name' => 'Santo Stefano')),
+
+            array('01.01.2016', null, null),
+            array('01.11.2016', null, array('name' => 'Dia de Todos os Santos')),
+            array('25.12.2016', null, array('name' => 'Natal')),
+
+            array('03.09.2017', null, null),
+            array('01.12.2017', null, array('name' => 'Restauração da Independência')),
+            array('10.06.2017', null, array('name' => 'Dia de Portugal')),
+        );
+    }
+}

--- a/tests/Checkdomain/Holiday/Provider/PTTest.php
+++ b/tests/Checkdomain/Holiday/Provider/PTTest.php
@@ -27,7 +27,7 @@ class PTTest extends AbstractTest
     public function dateProvider()
     {
         return array(
-			      array('01.01.2010', null, array('name' => 'Ano Novo')),
+            array('01.01.2010', null, array('name' => 'Ano Novo')),
 
             array('26.05.2013', null, null),
             array('25.04.2013', null, array('name' => '25 de Abril')),


### PR DESCRIPTION
The holidays listed are for the year 2017. We (Portuguese) disabled a few a couple of years back and we are re-enabling them little by little