### PR TITLE
Ignore development files when building packages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/phpunit.xml.dist export-ignore
+/test export-ignore


### PR DESCRIPTION
When building a package with Composer, we don't need development sources, like tests or Travis configurations. This PR instructs Composer to ignore development files when building version packages, reducing file size.