### PR TITLE
add 4 Bundesländer to $reformationDayStates

### DIFF
--- a/src/Provider/DE.php
+++ b/src/Provider/DE.php
@@ -50,6 +50,10 @@ class DE extends AbstractEaster
                 self::STATE_SN,
                 self::STATE_ST,
                 self::STATE_TH,
+                self::STATE_SH,
+                self::STATE_HH,
+                self::STATE_NI,
+                self::STATE_HB
             );
         }
 


### PR DESCRIPTION
Ab 2018 haben 4 zusätzliche Bundesländer den Reformationstag als Feiertag.

https://de.wikipedia.org/wiki/Reformationstag#Deutschland