### PR TITLE
Calculate correct easter date in BR provider

### DIFF
--- a/src/Provider/AbstractEaster.php
+++ b/src/Provider/AbstractEaster.php
@@ -66,6 +66,8 @@ abstract class AbstractEaster extends AbstractProvider
         $saturday->modify('-1 days');
         $ascensionDay = clone $easterSunday;
         $ascensionDay->modify('+39 days');
+        $shroveTuesday = clone $easterSunday;
+        $shroveTuesday->modify('-47 days');
 
 
         $pentecostSunday = clone $easterSunday;
@@ -78,6 +80,7 @@ abstract class AbstractEaster extends AbstractProvider
         $corpusChristi->modify('+60 days');
 
         return array(
+            'shroveTuesday' => $shroveTuesday,
             'maundyThursday' => $maundyThursday,
             'easterSunday' => $easterSunday,
             'easterMonday' => $easterMonday,

--- a/src/Provider/BR.php
+++ b/src/Provider/BR.php
@@ -2,9 +2,7 @@
 
 namespace Checkdomain\Holiday\Provider;
 
-use DateInterval;
 use DateTime;
-use DateTimeImmutable;
 
 /**
  * Brazilian Holiday Provider
@@ -13,7 +11,7 @@ use DateTimeImmutable;
  * @see http://www.planalto.gov.br/ccivil_03/leis/l6802.htm
  * @see https://pt.wikipedia.org/wiki/Feriados_no_Brasil
  */
-class BR extends AbstractProvider
+class BR extends AbstractEaster
 {
     const STATE_AC = 'Acre';
     const STATE_AL = 'Alagoas';
@@ -48,8 +46,7 @@ class BR extends AbstractProvider
      */
     public function getHolidaysByYear($year)
     {
-        // Easter
-        $easter = DateTimeImmutable::createFromFormat('U', easter_date($year));
+        $easter = $this->getEasterDates($year);
 
         $holidays = array(
             // National Fixed
@@ -62,9 +59,9 @@ class BR extends AbstractProvider
             '11-15' => $this->createData('Proclamação da República'),
             '12-25' => $this->createData('Natal'),
             // National Variable (and Optional)
-            $easter->sub(new DateInterval('P47D'))->format(self::DATE_FORMAT) => $this->createData('Carnaval'),
-            $easter->sub(new DateInterval('P2D'))->format(self::DATE_FORMAT)  => $this->createData('Sexta-Feira Santa'),
-            $easter->add(new DateInterval('P60D'))->format(self::DATE_FORMAT) => $this->createData('Corpus Christi'),
+            $easter['shroveTuesday']->format(self::DATE_FORMAT) => $this->createData('Carnaval'),
+            $easter['goodFriday']->format(self::DATE_FORMAT)  => $this->createData('Sexta-Feira Santa'),
+            $easter['corpusChristi']->format(self::DATE_FORMAT) => $this->createData('Corpus Christi'),
         );
 
         // Acre State
@@ -144,12 +141,6 @@ class BR extends AbstractProvider
         // Rio de Janeiro State
         $this->setHolidayForState($holidays, '04-23', self::STATE_RJ, 'São Jorge');
         $this->setHolidayForState($holidays, '11-20', self::STATE_RJ, 'Dia da Consciência Negra');
-        $this->setHolidayForState(
-            $holidays,
-            $easter->sub(new DateInterval('P47D'))->format(self::DATE_FORMAT),
-            self::STATE_RJ,
-            'Carnaval'
-        );
 
         // Rio Grande do Norte State
         $this->setHolidayForState($holidays, '10-03', self::STATE_RN, 'Mártires de Cunhaú e Uruaçu');


### PR DESCRIPTION
The Brazil provider sometimes calculates the wrong Easter date for a given year.

It uses `DateTimeImmutable::createFromFormat('U', easter_date($year))` -- which actually returns Saturday for timezones with a positive offset from UTC.

That's because `easter_date()` returns the UNIX timestamp for midnight on Easter Sunday, but **for the current timezone**. `DateTimeImmutable::createFromFormat` always uses UTC if a UNIX timestamp is provided, and for timezones with a positive offset midnight on Easter Sunday is actually Saturday afternoon or evening in UTC.

Accordingly, all Brazilian holidays relative to the Easter date are one day off under these circumstances.


This PR switches the Brazil provider to the `AbstractEaster` provider implementation which all the other providers are already using.

It also removes a duplicate: 'Carnaval' was defined both as a country-wide holiday and as a holiday for Rio de Janeiro state.