### PR TITLE
Added International Womens Day for Berlin, Germany

### DIFF
--- a/src/Provider/DE.php
+++ b/src/Provider/DE.php
@@ -79,6 +79,11 @@ class DE extends AbstractEaster
                 self::STATE_RP,
                 self::STATE_SL,
             )),
+            // International Women's Day
+            // @see https://de.wikipedia.org/wiki/Internationaler_Frauentag#Der_Frauentag_als_gesetzlicher_Feiertag
+            '03-08' => $this->createData('Internationaler Frauentag', array(
+                self::STATE_BE,
+            )),
 
             // Variable dates
             $easter['goodFriday']->format(self::DATE_FORMAT)      => $this->createData('Karfreitag'),

--- a/src/Provider/DE.php
+++ b/src/Provider/DE.php
@@ -79,11 +79,6 @@ class DE extends AbstractEaster
                 self::STATE_RP,
                 self::STATE_SL,
             )),
-            // International Women's Day
-            // @see https://de.wikipedia.org/wiki/Internationaler_Frauentag#Der_Frauentag_als_gesetzlicher_Feiertag
-            '03-08' => $this->createData('Internationaler Frauentag', array(
-                self::STATE_BE,
-            )),
 
             // Variable dates
             $easter['goodFriday']->format(self::DATE_FORMAT)      => $this->createData('Karfreitag'),
@@ -112,6 +107,14 @@ class DE extends AbstractEaster
                 self::STATE_SN
             ))
         );
+
+        if (2019 <= $year) {
+            // International Women's Day
+            // @see https://de.wikipedia.org/wiki/Internationaler_Frauentag#Der_Frauentag_als_gesetzlicher_Feiertag
+            $holidays['03-08'] = $this->createData('Internationaler Frauentag', array(
+                self::STATE_BE,
+            ));
+        }
 
         return $holidays;
     }

--- a/test/Provider/DETest.php
+++ b/test/Provider/DETest.php
@@ -38,8 +38,10 @@ class DETest extends AbstractTest
             array('2018-10-31', DE::STATE_SH, array('name' => 'Reformationstag')), 
             array('2018-11-21', DE::STATE_BB, null),
             array('2018-11-21', DE::STATE_SN, array('name' => 'Buß- und Bettag')),
-            array('2018-03-08', DE::STATE_BE, array('name' => 'Internationaler Frauentag')),
-            array('2018-03-08', DE::STATE_BY, null),
+            array('2018-03-08', DE::STATE_BE, null),
+            array('2019-03-08', DE::STATE_BE, array('name' => 'Internationaler Frauentag')),
+            array('2021-03-08', DE::STATE_BE, array('name' => 'Internationaler Frauentag')),
+            array('2021-03-08', DE::STATE_BY, null),
         );
     }
 }

--- a/test/Provider/DETest.php
+++ b/test/Provider/DETest.php
@@ -38,6 +38,8 @@ class DETest extends AbstractTest
             array('2018-10-31', DE::STATE_SH, array('name' => 'Reformationstag')), 
             array('2018-11-21', DE::STATE_BB, null),
             array('2018-11-21', DE::STATE_SN, array('name' => 'Buß- und Bettag')),
+            array('2018-03-08', DE::STATE_BE, array('name' => 'Internationaler Frauentag')),
+            array('2018-03-08', DE::STATE_BY, null),
         );
     }
 }


### PR DESCRIPTION
See https://de.wikipedia.org/wiki/Internationaler_Frauentag#Der_Frauentag_als_gesetzlicher_Feiertag
or
https://www.dw.com/en/berlin-declares-international-womens-day-a-public-holiday/a-47215264