### PR TITLE
Reunion: Remove state-specific data inherited from France

### DIFF
--- a/src/Provider/RE.php
+++ b/src/Provider/RE.php
@@ -19,6 +19,11 @@ class RE extends FR
     {
         // sames rules as France
         $holidays = parent::getHolidaysByYear($year);
+
+        // remove holidays for specific states
+        foreach($holidays as $date => $holiday) {
+            if (isset($holiday['states']) && $holiday['states']) unset($holidays[$date]);
+        }
         // but an additional date
         $holidays['12-20'] = $this->createData('Abolition de l\'Esclavage');
 


### PR DESCRIPTION
Hello,

Holidays from specific states of France should not be inherited in Reunion.

I fixed that in that commit.

Thanks.