### PR TITLE
Fix PHP 8.4 deprecation notice

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -85,7 +85,7 @@ abstract class AbstractProvider implements ProviderInterface
      *
      * @return array
      */
-    protected function createData($name, array $states = null)
+    protected function createData($name, ?array $states = null)
     {
         return array(
             'name'     => $name,


### PR DESCRIPTION
Fixes the following deprecation notice in php >=8.4:

```
src/Provider/AbstractProvider.php:88
Checkdomain\Holiday\Provider\AbstractProvider::createData(): Implicitly marking parameter $states as nullable is deprecated, the explicit nullable type must be used instead
```

